### PR TITLE
Added DOWNLOAD_CLOUD functionality, reworked the parameter file, smaller fixes

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -79,9 +79,10 @@ Usage
 Contributing
 ============
 
-We welcome community contributions!
+**lksearch**  is an open-source, community driven package. 
+We welcome users to contribute and develop new features for lksearch.  
 
-Guidelines TBD
+For further information, please see the `Lightkurve Community guidelines <https://docs.lightkurve.org/development/contributing.html>`_.
 
 .. <!-- Contributing content end -->
 
@@ -92,7 +93,11 @@ Citing
 
 If you find **lksearch** useful in your research, please cite it and give us a GitHub star!
 
-Citation Instructions TBD
+If you use Lightkurve for work or research presented in a publication, we request the following acknowledgment or citation:
+
+`This research made use of Lightkurve, a Python package for Kepler and TESS data analysis (Lightkurve Collaboration, 2018).`
+
+See full citation instuctions, including dependencies, in the `Lightkurve documentation <https://docs.lightkurve.org/about/citing.html>`_. 
 
 .. <!-- Citing content end -->
 

--- a/docs/apidoc.rst
+++ b/docs/apidoc.rst
@@ -14,3 +14,6 @@ API documentation
    
 .. autoclass:: lksearch.TESSSearch
    :members:
+
+.. automodule:: lksearch.config
+   :members:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -2,6 +2,7 @@
    sphinx-quickstart on Mon Apr 22 14:10:27 2024.
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.
+
 ########
 lksearch
 ########

--- a/docs/tutorials/Example_searches.ipynb
+++ b/docs/tutorials/Example_searches.ipynb
@@ -15,7 +15,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from tssc import MASTSearch, KeplerSearch, K2Search, TESSSearch"
+    "from lksearch import MASTSearch, KeplerSearch, K2Search, TESSSearch"
    ]
   },
   {
@@ -2557,7 +2557,21 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "pipeline products: 100%|███████████████████████████████████████████████████████████| 2/2 [00:20<00:00, 10.50s/it]\n"
+      "pipeline products: 100%|██████████████████████████| 2/2 [00:03<00:00,  1.87s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "True\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n"
      ]
     },
     {
@@ -2581,6 +2595,7 @@
        "  <thead>\n",
        "    <tr style=\"text-align: right;\">\n",
        "      <th></th>\n",
+       "      <th>index</th>\n",
        "      <th>Local Path</th>\n",
        "      <th>Status</th>\n",
        "      <th>Message</th>\n",
@@ -2590,14 +2605,16 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>0</th>\n",
-       "      <td>/Users/tapritc2/.tssc/cache/mastDownload/TESS/...</td>\n",
+       "      <td>0</td>\n",
+       "      <td>/Users/tapritc2/.lksearch/cache/mastDownload/T...</td>\n",
        "      <td>COMPLETE</td>\n",
        "      <td>None</td>\n",
        "      <td>None</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>/Users/tapritc2/.tssc/cache/mastDownload/HLSP/...</td>\n",
+       "      <th>1</th>\n",
+       "      <td>0</td>\n",
+       "      <td>/Users/tapritc2/.lksearch/cache/mastDownload/H...</td>\n",
        "      <td>COMPLETE</td>\n",
        "      <td>None</td>\n",
        "      <td>None</td>\n",
@@ -2607,9 +2624,13 @@
        "</div>"
       ],
       "text/plain": [
-       "                                          Local Path    Status Message   URL\n",
-       "0  /Users/tapritc2/.tssc/cache/mastDownload/TESS/...  COMPLETE    None  None\n",
-       "0  /Users/tapritc2/.tssc/cache/mastDownload/HLSP/...  COMPLETE    None  None"
+       "   index                                         Local Path    Status Message  \\\n",
+       "0      0  /Users/tapritc2/.lksearch/cache/mastDownload/T...  COMPLETE    None   \n",
+       "1      0  /Users/tapritc2/.lksearch/cache/mastDownload/H...  COMPLETE    None   \n",
+       "\n",
+       "    URL  \n",
+       "0  None  \n",
+       "1  None  "
       ]
      },
      "execution_count": 16,
@@ -2798,7 +2819,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "TESScut          : 100%|███████████████████████████████████████████████████████████| 1/1 [00:25<00:00, 25.84s/it]\n"
+      "TESScut          : 100%|██████████████████████████| 1/1 [00:03<00:00,  3.22s/it]\n"
      ]
     },
     {
@@ -2829,7 +2850,7 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>0</th>\n",
-       "      <td>/Users/tapritc2/.tssc/cache/mastDownload/TESSC...</td>\n",
+       "      <td>/Users/tapritc2/.lksearch/cache/mastDownload/T...</td>\n",
        "      <td>COMPLETE</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
@@ -2838,7 +2859,7 @@
       ],
       "text/plain": [
        "                                          Local Path    Status\n",
-       "0  /Users/tapritc2/.tssc/cache/mastDownload/TESSC...  COMPLETE"
+       "0  /Users/tapritc2/.lksearch/cache/mastDownload/T...  COMPLETE"
       ]
      },
      "execution_count": 18,
@@ -2871,7 +2892,7 @@
     {
      "data": {
       "text/html": [
-       "TESSSearch object containing 152 data products<div>\n",
+       "TESSSearch object containing 160 data products<div>\n",
        "<style scoped>\n",
        "    .dataframe tbody tr th:only-of-type {\n",
        "        vertical-align: middle;\n",
@@ -2967,7 +2988,7 @@
        "      <td>...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>147</th>\n",
+       "      <th>155</th>\n",
        "      <td>299096355</td>\n",
        "      <td>CDIPS</td>\n",
        "      <td>HLSP</td>\n",
@@ -2978,7 +2999,7 @@
        "      <td>FITS</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>148</th>\n",
+       "      <th>156</th>\n",
        "      <td>299096355</td>\n",
        "      <td>QLP</td>\n",
        "      <td>HLSP</td>\n",
@@ -2989,7 +3010,7 @@
        "      <td>FITS</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>149</th>\n",
+       "      <th>157</th>\n",
        "      <td>299096355</td>\n",
        "      <td>CDIPS</td>\n",
        "      <td>HLSP</td>\n",
@@ -3000,7 +3021,7 @@
        "      <td>FITS</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>150</th>\n",
+       "      <th>158</th>\n",
        "      <td>299096355</td>\n",
        "      <td>QLP</td>\n",
        "      <td>HLSP</td>\n",
@@ -3011,7 +3032,7 @@
        "      <td>FITS</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>151</th>\n",
+       "      <th>159</th>\n",
        "      <td>299096355</td>\n",
        "      <td>QLP</td>\n",
        "      <td>HLSP</td>\n",
@@ -3023,22 +3044,22 @@
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
-       "<p>152 rows × 8 columns</p>\n",
+       "<p>160 rows × 8 columns</p>\n",
        "</div>"
       ],
       "text/plain": [
-       "TESSSearch object containing 152 data products    target_name pipeline mission  sector  exptime  distance  year  \\\n",
+       "TESSSearch object containing 160 data products    target_name pipeline mission  sector  exptime  distance  year  \\\n",
        "0     299096355     SPOC    TESS      14    120.0       0.0  2019   \n",
        "1     299096355     SPOC    TESS      14    120.0       0.0  2019   \n",
        "2     299096355     SPOC    TESS      14    120.0       0.0  2019   \n",
        "3     299096355     SPOC    TESS      14    120.0       0.0  2019   \n",
        "4     299096355     SPOC    TESS      14    120.0       0.0  2019   \n",
        "..          ...      ...     ...     ...      ...       ...   ...   \n",
-       "147   299096355    CDIPS    HLSP      54   1800.0       0.0  2022   \n",
-       "148   299096355      QLP    HLSP      54    600.0       0.0  2022   \n",
-       "149   299096355    CDIPS    HLSP      55   1800.0       0.0  2022   \n",
-       "150   299096355      QLP    HLSP      55    600.0       0.0  2022   \n",
-       "151   299096355      QLP    HLSP      56    200.0       0.0  2022   \n",
+       "155   299096355    CDIPS    HLSP      54   1800.0       0.0  2022   \n",
+       "156   299096355      QLP    HLSP      54    600.0       0.0  2022   \n",
+       "157   299096355    CDIPS    HLSP      55   1800.0       0.0  2022   \n",
+       "158   299096355      QLP    HLSP      55    600.0       0.0  2022   \n",
+       "159   299096355      QLP    HLSP      56    200.0       0.0  2022   \n",
        "\n",
        "                     description  \n",
        "0    full data validation report  \n",
@@ -3047,13 +3068,13 @@
        "3    Data validation mini report  \n",
        "4             TCE summary report  \n",
        "..                           ...  \n",
-       "147                         FITS  \n",
-       "148                         FITS  \n",
-       "149                         FITS  \n",
-       "150                         FITS  \n",
-       "151                         FITS  \n",
+       "155                         FITS  \n",
+       "156                         FITS  \n",
+       "157                         FITS  \n",
+       "158                         FITS  \n",
+       "159                         FITS  \n",
        "\n",
-       "[152 rows x 8 columns]"
+       "[160 rows x 8 columns]"
       ]
      },
      "execution_count": 19,
@@ -3289,7 +3310,21 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "pipeline products: 100%|███████████████████████████████████████████████████████████| 1/1 [00:01<00:00,  1.95s/it]\n"
+      "pipeline products: 100%|██████████████████████████| 1/1 [00:01<00:00,  1.23s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "True\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n"
      ]
     },
     {
@@ -3313,6 +3348,7 @@
        "  <thead>\n",
        "    <tr style=\"text-align: right;\">\n",
        "      <th></th>\n",
+       "      <th>index</th>\n",
        "      <th>Local Path</th>\n",
        "      <th>Status</th>\n",
        "      <th>Message</th>\n",
@@ -3322,7 +3358,8 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>0</th>\n",
-       "      <td>/Users/tapritc2/.tssc/cache/mastDownload/TESS/...</td>\n",
+       "      <td>0</td>\n",
+       "      <td>/Users/tapritc2/.lksearch/cache/mastDownload/T...</td>\n",
        "      <td>COMPLETE</td>\n",
        "      <td>None</td>\n",
        "      <td>None</td>\n",
@@ -3332,8 +3369,11 @@
        "</div>"
       ],
       "text/plain": [
-       "                                          Local Path    Status Message   URL\n",
-       "0  /Users/tapritc2/.tssc/cache/mastDownload/TESS/...  COMPLETE    None  None"
+       "   index                                         Local Path    Status Message  \\\n",
+       "0      0  /Users/tapritc2/.lksearch/cache/mastDownload/T...  COMPLETE    None   \n",
+       "\n",
+       "    URL  \n",
+       "0  None  "
       ]
      },
      "execution_count": 21,
@@ -3485,7 +3525,7 @@
        "      <td>1800.000</td>\n",
        "      <td>0.0</td>\n",
        "      <td>2009</td>\n",
-       "      <td>Data Validation summary report</td>\n",
+       "      <td>Data Validation full report</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>79</th>\n",
@@ -3507,7 +3547,7 @@
        "      <td>1800.000</td>\n",
        "      <td>0.0</td>\n",
        "      <td>2009</td>\n",
-       "      <td>Data Validation full report</td>\n",
+       "      <td>Data Validation summary report</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>81</th>\n",
@@ -3547,9 +3587,9 @@
        "4        0.0  2009     Lightcurve Long Cadence (CLC) - Q2  \n",
        "..       ...   ...                                    ...  \n",
        "77       0.0  2013  Target Pixel Long Cadence (TPL) - Q17  \n",
-       "78       0.0  2009         Data Validation summary report  \n",
+       "78       0.0  2009            Data Validation full report  \n",
        "79       0.0  2009         Data Validation summary report  \n",
-       "80       0.0  2009            Data Validation full report  \n",
+       "80       0.0  2009         Data Validation summary report  \n",
        "81       0.0  2009                                   FITS  \n",
        "\n",
        "[82 rows x 8 columns]"
@@ -3780,7 +3820,21 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "pipeline products: 100%|███████████████████████████████████████████████████████████| 2/2 [00:12<00:00,  6.36s/it]\n"
+      "pipeline products: 100%|██████████████████████████| 2/2 [00:05<00:00,  2.56s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "True\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n"
      ]
     },
     {
@@ -3804,6 +3858,7 @@
        "  <thead>\n",
        "    <tr style=\"text-align: right;\">\n",
        "      <th></th>\n",
+       "      <th>index</th>\n",
        "      <th>Local Path</th>\n",
        "      <th>Status</th>\n",
        "      <th>Message</th>\n",
@@ -3813,14 +3868,16 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>0</th>\n",
-       "      <td>/Users/tapritc2/.tssc/cache/mastDownload/Keple...</td>\n",
+       "      <td>0</td>\n",
+       "      <td>/Users/tapritc2/.lksearch/cache/mastDownload/K...</td>\n",
        "      <td>COMPLETE</td>\n",
        "      <td>None</td>\n",
        "      <td>None</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>/Users/tapritc2/.tssc/cache/mastDownload/Keple...</td>\n",
+       "      <th>1</th>\n",
+       "      <td>0</td>\n",
+       "      <td>/Users/tapritc2/.lksearch/cache/mastDownload/K...</td>\n",
        "      <td>COMPLETE</td>\n",
        "      <td>None</td>\n",
        "      <td>None</td>\n",
@@ -3830,9 +3887,13 @@
        "</div>"
       ],
       "text/plain": [
-       "                                          Local Path    Status Message   URL\n",
-       "0  /Users/tapritc2/.tssc/cache/mastDownload/Keple...  COMPLETE    None  None\n",
-       "0  /Users/tapritc2/.tssc/cache/mastDownload/Keple...  COMPLETE    None  None"
+       "   index                                         Local Path    Status Message  \\\n",
+       "0      0  /Users/tapritc2/.lksearch/cache/mastDownload/K...  COMPLETE    None   \n",
+       "1      0  /Users/tapritc2/.lksearch/cache/mastDownload/K...  COMPLETE    None   \n",
+       "\n",
+       "    URL  \n",
+       "0  None  \n",
+       "1  None  "
       ]
      },
      "execution_count": 24,
@@ -3863,15 +3924,16 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "pipeline products: 100%|███████████████████████████████████████████████████████████| 2/2 [00:03<00:00,  1.99s/it]"
+      "pipeline products: 100%|██████████████████████████| 2/2 [00:08<00:00,  4.08s/it]"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "['/Users/tapritc2/.tssc/cache/mastDownload/Kepler/kplr007419318_lc_Q111111111111111111/kplr007419318-2009131105131_llc.fits'\n",
-      " '/Users/tapritc2/.tssc/cache/mastDownload/Kepler/kplr007419318_lc_Q111111111111111111/kplr007419318-2009131105131_lpd-targ.fits.gz']\n"
+      "True\n",
+      "['/Users/tapritc2/.lksearch/cache/mastDownload/Kepler/kplr007419318_lc_Q111111111111111111/kplr007419318-2009131105131_llc.fits'\n",
+      " '/Users/tapritc2/.lksearch/cache/mastDownload/Kepler/kplr007419318_lc_Q111111111111111111/kplr007419318-2009131105131_lpd-targ.fits.gz']\n"
      ]
     },
     {
@@ -3957,7 +4019,7 @@
        "      <td>60.0</td>\n",
        "      <td>0.0</td>\n",
        "      <td>2010</td>\n",
-       "      <td>Lightcurve Short Cadence (CSC) - Q7</td>\n",
+       "      <td>Target Pixel Short Cadence (TPS) - Q7</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3</th>\n",
@@ -3990,7 +4052,7 @@
        "      <td>60.0</td>\n",
        "      <td>0.0</td>\n",
        "      <td>2010</td>\n",
-       "      <td>Target Pixel Short Cadence (TPS) - Q7</td>\n",
+       "      <td>Lightcurve Short Cadence (CSC) - Q7</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>6</th>\n",
@@ -4001,7 +4063,7 @@
        "      <td>1800.0</td>\n",
        "      <td>0.0</td>\n",
        "      <td>2010</td>\n",
-       "      <td>Lightcurve Long Cadence (CLC) - Q7</td>\n",
+       "      <td>Target Pixel Long Cadence (TPL) - Q7</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>7</th>\n",
@@ -4012,7 +4074,7 @@
        "      <td>1800.0</td>\n",
        "      <td>0.0</td>\n",
        "      <td>2010</td>\n",
-       "      <td>Target Pixel Long Cadence (TPL) - Q7</td>\n",
+       "      <td>Lightcurve Long Cadence (CLC) - Q7</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>8</th>\n",
@@ -4056,12 +4118,12 @@
        "                             description  \n",
        "0    Lightcurve Short Cadence (CSC) - Q7  \n",
        "1    Lightcurve Short Cadence (CSC) - Q7  \n",
-       "2    Lightcurve Short Cadence (CSC) - Q7  \n",
+       "2  Target Pixel Short Cadence (TPS) - Q7  \n",
        "3  Target Pixel Short Cadence (TPS) - Q7  \n",
        "4  Target Pixel Short Cadence (TPS) - Q7  \n",
-       "5  Target Pixel Short Cadence (TPS) - Q7  \n",
-       "6     Lightcurve Long Cadence (CLC) - Q7  \n",
-       "7   Target Pixel Long Cadence (TPL) - Q7  \n",
+       "5    Lightcurve Short Cadence (CSC) - Q7  \n",
+       "6   Target Pixel Long Cadence (TPL) - Q7  \n",
+       "7     Lightcurve Long Cadence (CLC) - Q7  \n",
        "8    Lightcurve Long Cadence (CLC) - Q17  \n",
        "9  Target Pixel Long Cadence (TPL) - Q17  "
       ]
@@ -4089,10 +4151,135 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 27,
    "id": "a775a2f7",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "K2Search object containing 6 data products<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>target_name</th>\n",
+       "      <th>pipeline</th>\n",
+       "      <th>mission</th>\n",
+       "      <th>campaign</th>\n",
+       "      <th>exptime</th>\n",
+       "      <th>distance</th>\n",
+       "      <th>year</th>\n",
+       "      <th>description</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>ktwo201912552</td>\n",
+       "      <td>K2</td>\n",
+       "      <td>K2</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1800.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>2014</td>\n",
+       "      <td>Target Pixel Long Cadence (KTL) - C01</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>ktwo201912552</td>\n",
+       "      <td>K2</td>\n",
+       "      <td>K2</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1800.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>2014</td>\n",
+       "      <td>Lightcurve Long Cadence (KLC) - C01</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>ktwo201912552</td>\n",
+       "      <td>EVEREST</td>\n",
+       "      <td>HLSP</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1800.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>2014</td>\n",
+       "      <td>FITS</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>ktwo201912552</td>\n",
+       "      <td>EVEREST</td>\n",
+       "      <td>HLSP</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1800.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>2014</td>\n",
+       "      <td>PDF</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>ktwo201912552</td>\n",
+       "      <td>K2SFF</td>\n",
+       "      <td>HLSP</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1800.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>2014</td>\n",
+       "      <td>FITS</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5</th>\n",
+       "      <td>ktwo201912552</td>\n",
+       "      <td>K2VARCAT</td>\n",
+       "      <td>HLSP</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1800.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>2014</td>\n",
+       "      <td>FITS</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "K2Search object containing 6 data products     target_name  pipeline mission campaign  exptime  distance  year  \\\n",
+       "0  ktwo201912552        K2      K2        1   1800.0       0.0  2014   \n",
+       "1  ktwo201912552        K2      K2        1   1800.0       0.0  2014   \n",
+       "2  ktwo201912552   EVEREST    HLSP        1   1800.0       0.0  2014   \n",
+       "3  ktwo201912552   EVEREST    HLSP        1   1800.0       0.0  2014   \n",
+       "4  ktwo201912552     K2SFF    HLSP        1   1800.0       0.0  2014   \n",
+       "5  ktwo201912552  K2VARCAT    HLSP        1   1800.0       0.0  2014   \n",
+       "\n",
+       "                             description  \n",
+       "0  Target Pixel Long Cadence (KTL) - C01  \n",
+       "1    Lightcurve Long Cadence (KLC) - C01  \n",
+       "2                                   FITS  \n",
+       "3                                    PDF  \n",
+       "4                                   FITS  \n",
+       "5                                   FITS  "
+      ]
+     },
+     "execution_count": 27,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "K2 = K2Search(\"K2-18\")\n",
     "K2"
@@ -4100,10 +4287,109 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 28,
    "id": "7d27bf57",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "K2Search object containing 4 data products<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>target_name</th>\n",
+       "      <th>pipeline</th>\n",
+       "      <th>mission</th>\n",
+       "      <th>campaign</th>\n",
+       "      <th>exptime</th>\n",
+       "      <th>distance</th>\n",
+       "      <th>year</th>\n",
+       "      <th>description</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>ktwo201912552</td>\n",
+       "      <td>EVEREST</td>\n",
+       "      <td>HLSP</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1800.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>2014</td>\n",
+       "      <td>FITS</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>ktwo201912552</td>\n",
+       "      <td>EVEREST</td>\n",
+       "      <td>HLSP</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1800.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>2014</td>\n",
+       "      <td>PDF</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>ktwo201912552</td>\n",
+       "      <td>K2SFF</td>\n",
+       "      <td>HLSP</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1800.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>2014</td>\n",
+       "      <td>FITS</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>ktwo201912552</td>\n",
+       "      <td>K2VARCAT</td>\n",
+       "      <td>HLSP</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1800.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>2014</td>\n",
+       "      <td>FITS</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "K2Search object containing 4 data products     target_name  pipeline mission campaign  exptime  distance  year  \\\n",
+       "0  ktwo201912552   EVEREST    HLSP        1   1800.0       0.0  2014   \n",
+       "1  ktwo201912552   EVEREST    HLSP        1   1800.0       0.0  2014   \n",
+       "2  ktwo201912552     K2SFF    HLSP        1   1800.0       0.0  2014   \n",
+       "3  ktwo201912552  K2VARCAT    HLSP        1   1800.0       0.0  2014   \n",
+       "\n",
+       "  description  \n",
+       "0        FITS  \n",
+       "1         PDF  \n",
+       "2        FITS  \n",
+       "3        FITS  "
+      ]
+     },
+     "execution_count": 28,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "# Download all lightcurves produced by HLSPs\n",
     "K2_HLSPs = K2.HLSPs\n",
@@ -4112,22 +4398,287 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 29,
    "id": "c2cd7ee3",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "pipeline products: 100%|██████████████████████████| 3/3 [00:01<00:00,  2.50it/s]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "True\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>index</th>\n",
+       "      <th>Local Path</th>\n",
+       "      <th>Status</th>\n",
+       "      <th>Message</th>\n",
+       "      <th>URL</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>0</td>\n",
+       "      <td>/Users/tapritc2/.lksearch/cache/mastDownload/H...</td>\n",
+       "      <td>COMPLETE</td>\n",
+       "      <td>None</td>\n",
+       "      <td>None</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>0</td>\n",
+       "      <td>/Users/tapritc2/.lksearch/cache/mastDownload/H...</td>\n",
+       "      <td>COMPLETE</td>\n",
+       "      <td>None</td>\n",
+       "      <td>None</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>0</td>\n",
+       "      <td>/Users/tapritc2/.lksearch/cache/mastDownload/H...</td>\n",
+       "      <td>COMPLETE</td>\n",
+       "      <td>None</td>\n",
+       "      <td>None</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   index                                         Local Path    Status Message  \\\n",
+       "0      0  /Users/tapritc2/.lksearch/cache/mastDownload/H...  COMPLETE    None   \n",
+       "1      0  /Users/tapritc2/.lksearch/cache/mastDownload/H...  COMPLETE    None   \n",
+       "2      0  /Users/tapritc2/.lksearch/cache/mastDownload/H...  COMPLETE    None   \n",
+       "\n",
+       "    URL  \n",
+       "0  None  \n",
+       "1  None  \n",
+       "2  None  "
+      ]
+     },
+     "execution_count": 29,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "manifest = K2_HLSPs.timeseries.download()\n",
     "manifest"
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "a42fd1bd-f70a-4db9-b483-3a39f4787d4c",
+   "metadata": {},
+   "source": [
+    "## Configuration and Caching\n",
+    "\n",
+    "`lksearch` has a default file download location that serves as the file cache, and an optional configuration file that can be created and used to overwrite the default values"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "03f52bd0-c5d3-4974-9b3a-dfd0c3d1a248",
+   "metadata": {},
+   "source": [
+    "### lksearch File Download and Cache\n",
+    "The `lksearch` file cache is a directory where files are downloaded to.  This directory also serves as a cache directory, and if a file matching the name of the file to be downloaded exists we treat this as a cached file and by default do not overwrite the current file on disk.  \n",
+    "\n",
+    "The default file download and cache directory is located at:\n",
+    "`~/.lksearch/cache`\n",
+    "\n",
+    "This can be verified using the get_cache_dir convenience function in the config sub-module, e.g.:"
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "7dfa491c",
+   "execution_count": 30,
+   "id": "5ebda13a-0051-48c7-8272-e6aa3040f4b2",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'/Users/tapritc2/.lksearch/cache'"
+      ]
+     },
+     "execution_count": 30,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from lksearch import config as lkconfig\n",
+    "lkconfig.get_cache_dir()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e70e062e-d0f8-45e0-b01a-06cec8da54e5",
+   "metadata": {},
+   "source": [
+    "#### Clearing the Cache & Corrupted Files\n",
+    "If you wish to delete an individual file that you downloaded (for example, if you are concerned that a previously downloaded file is corrupted), the easiest way to do that is using the `Local Path` information in the manifest returned by the `.download()` function."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 31,
+   "id": "6e6625e2-c1c2-40fb-8fd2-fa3633cf3722",
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "import os\n",
+    "# The manifest returned by download() is a pandas DataFrame\n",
+    "# We will access the first local path using iloc as so\n",
+    "os.remove(manifest.iloc[0][\"Local Path\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7ffa2d24-eba6-48fd-9f59-12a348dcb08d",
+   "metadata": {},
+   "source": [
+    "If you want to clear *everything* from your cache, you can use the `config.clearcache()` function to completely empty your cache of downloaded files. by default this will run in \"test\" mode and print what you will be deleting.  To confirm deletion, run with `test=False` optional parameter.  "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 32,
+   "id": "1345bf88-74be-4aea-96c9-512ab31b349b",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Running in test mode, rerun with test=False to clear cache\n",
+      "removing /Users/tapritc2/.lksearch/cache/mastDownload/TESS\n",
+      "removing /Users/tapritc2/.lksearch/cache/mastDownload/K2\n",
+      "removing /Users/tapritc2/.lksearch/cache/mastDownload/Kepler\n",
+      "removing /Users/tapritc2/.lksearch/cache/mastDownload/TESSCut\n",
+      "removing /Users/tapritc2/.lksearch/cache/mastDownload/HLSP\n"
+     ]
+    }
+   ],
+   "source": [
+    "lkconfig.clearcache()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6291a748-1e67-41b1-8049-57aabe2b744b",
+   "metadata": {},
+   "source": [
+    "**Passing `test=False` will then fully delete the above directories** \n",
+    "\n",
+    "e.g. `lkconfig.clearcache(test=False)`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9adc419e-91b3-41bc-bc40-d37b5c628ebe",
+   "metadata": {},
+   "source": [
+    "### lksearch Configuration file\n",
+    "lksearch also has an optional configuration file that is built on-top of `~astropy.config` using `~astropy.config.ConfigNamespace`. This file does not exist by default, but a default version can be created using the `config.create_config_file` helper function.  "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 33,
+   "id": "345bb5e5-7b13-4ee8-9a08-c85de036ace4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "lkconfig.create_config_file(overwrite = True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1561451f-d3c0-4df9-bdb9-343b63e0f136",
+   "metadata": {},
+   "source": [
+    "This file can be found in the below location.  To edit this, please see the astropy.config documentation.  "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 34,
+   "id": "be7bc33c-eb6c-4ce7-81f8-d98076581cc4",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'/Users/tapritc2/.lksearch/config'"
+      ]
+     },
+     "execution_count": 34,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "lkconfig.get_config_dir()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 35,
+   "id": "341857e6-aa78-4cc6-b68d-79fca23f7e63",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'/Users/tapritc2/.lksearch/config/lksearch.cfg'"
+      ]
+     },
+     "execution_count": 35,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "lkconfig.get_config_file()"
+   ]
   }
  ],
  "metadata": {

--- a/src/lksearch/K2Search.py
+++ b/src/lksearch/K2Search.py
@@ -16,11 +16,9 @@ from copy import deepcopy
 
 from .utils import SearchError, SearchWarning, suppress_stdout
 from .MASTSearch import MASTSearch
-from . import PACKAGEDIR, PREFER_CLOUD, DOWNLOAD_CLOUD, conf, config
+from . import PACKAGEDIR, conf, config
 
 pd.options.display.max_rows = 10
-
-default_download_dir = config.get_cache_dir()
 
 log = logging.getLogger(__name__)
 

--- a/src/lksearch/KeplerSearch.py
+++ b/src/lksearch/KeplerSearch.py
@@ -16,11 +16,9 @@ from copy import deepcopy
 
 from .utils import SearchError, SearchWarning, suppress_stdout
 from .MASTSearch import MASTSearch
-from . import PACKAGEDIR, PREFER_CLOUD, DOWNLOAD_CLOUD, conf, config
+from . import PACKAGEDIR, conf, config
 
 pd.options.display.max_rows = 10
-
-default_download_dir = config.get_cache_dir()
 
 log = logging.getLogger(__name__)
 

--- a/src/lksearch/MASTSearch.py
+++ b/src/lksearch/MASTSearch.py
@@ -17,7 +17,7 @@ from copy import deepcopy
 
 from .utils import SearchError, SearchWarning, suppress_stdout
 
-from . import PACKAGEDIR, PREFER_CLOUD, DOWNLOAD_CLOUD, conf, config
+from . import PACKAGEDIR, conf, config
 
 pd.options.display.max_rows = 10
 
@@ -1006,17 +1006,19 @@ class MASTSearch(object):
             download only products availaible in the cloud, by default False
         download_dir : str, optional
             directory where the products should be downloaded to,
-             by default default_download_dir
+            by default default_download_dir
             cache : bool, optional
         passed to `~astroquery.mast.Observations.download_products`, by default True
             if False, will overwrite the file to be downloaded (for example to replace a corrrupted file)
         remove_incomplete: str, optional
             remove files with a status not "COMPLETE" in the manifest, by default True
+
         Returns
         -------
         ~pandas.DataFrame
             table where each row is an ~astroquery.mast.Observations.download_products()
             manifest
+
         """
 
         if len(self.table) == 0:

--- a/src/lksearch/TESSSearch.py
+++ b/src/lksearch/TESSSearch.py
@@ -19,11 +19,12 @@ from copy import deepcopy
 
 from .utils import SearchError, SearchWarning, suppress_stdout
 from .MASTSearch import MASTSearch
-from . import PACKAGEDIR, PREFER_CLOUD, DOWNLOAD_CLOUD, conf, config
+from . import PACKAGEDIR, conf, config
+
+PREFER_CLOUD = conf.PREFER_CLOUD
+DOWNLOAD_CLOUD = conf.DOWNLOAD_CLOUD
 
 pd.options.display.max_rows = 10
-
-default_download_dir = config.get_cache_dir()
 
 log = logging.getLogger(__name__)
 
@@ -427,10 +428,10 @@ class TESSSearch(MASTSearch):
 
     def download(
         self,
-        cloud: PREFER_CLOUD = True,
-        cache: PREFER_CLOUD = True,
-        cloud_only: PREFER_CLOUD = False,
-        download_dir: PACKAGEDIR = default_download_dir,
+        cloud: bool = conf.PREFER_CLOUD,
+        cache: bool = True,
+        cloud_only: bool = conf.CLOUD_ONLY,
+        download_dir: str = config.get_cache_dir(),
         # TESScut_product="SPOC",
         TESScut_size=10,
     ):
@@ -441,7 +442,7 @@ class TESSSearch(MASTSearch):
             mast_mf = super().download(cloud, cache, cloud_only, download_dir)
 
         elif "TESScut" in self.table.provenance_name.unique():
-            TESSCut_dir = f"{default_download_dir}/mastDownload/TESSCut"
+            TESSCut_dir = f"{download_dir}/mastDownload/TESSCut"
             if not os.path.isdir(TESSCut_dir):
                 os.makedirs(TESSCut_dir)
             mask = self.table["provenance_name"] == "TESScut"
@@ -459,7 +460,7 @@ class TESSSearch(MASTSearch):
                     # Uncomment when astroquery 0.4.8 is released to enable TICA support
                     # product=TESScut_product,
                     # verbose=False
-                    path=f"{default_download_dir}/mastDownload/TESSCut",
+                    path=f"{download_dir}/mastDownload/TESSCut",
                     inflate=True,
                     moving_target=False,  # this could be added
                     mt_type=None,
@@ -469,7 +470,7 @@ class TESSSearch(MASTSearch):
                     sector_list, total=len(sector_list), desc="TESScut          "
                 )
             ]
-        if len(mast_mf) != 0:
+        if len(np.atleast_1d(mast_mf)) != 0:
             manifest = mast_mf
 
         if len(tesscut_mf) != 0:

--- a/src/lksearch/TESSSearch.py
+++ b/src/lksearch/TESSSearch.py
@@ -433,8 +433,35 @@ class TESSSearch(MASTSearch):
         cloud_only: bool = conf.CLOUD_ONLY,
         download_dir: str = config.get_cache_dir(),
         # TESScut_product="SPOC",
-        TESScut_size: int = 10,
+        TESScut_size: Union[int, tuple] = 10,
     ):
+        """downloads products in self.table to the local hard-drive
+
+        Parameters
+        ----------
+        cloud : bool, optional
+            enable cloud (as opposed to MAST) downloading, by default True
+        cloud_only : bool, optional
+            download only products availaible in the cloud, by default False
+        download_dir : str, optional
+            directory where the products should be downloaded to,
+            by default default_download_dir
+            cache : bool, optional
+        passed to `~astroquery.mast.Observations.download_products`, by default True
+            if False, will overwrite the file to be downloaded (for example to replace a corrrupted file)
+        remove_incomplete: str, optional
+            remove files with a status not "COMPLETE" in the manifest, by default True
+        TESScut_size : Union[int, tuple], optional,
+            The size of a TESScut FFI cutout in pixels
+
+        Returns
+        -------
+        ~pandas.DataFrame
+            table where each row is an ~astroquery.mast.Observations.download_products()
+            manifest
+
+        """
+
         mast_mf = []
         tesscut_mf = []
         manifest = []

--- a/src/lksearch/__init__.py
+++ b/src/lksearch/__init__.py
@@ -20,7 +20,7 @@ class Conf(_config.ConfigNamespace):
 
     The attributes listed below are the available configuration parameters.
 
-    Attributes
+    Parameters
     ----------
     search_result_display_extra_columns
         List of extra columns to be included when displaying a SearchResult object.

--- a/src/lksearch/__init__.py
+++ b/src/lksearch/__init__.py
@@ -5,8 +5,6 @@ from . import config as _config
 import os
 
 PACKAGEDIR = os.path.abspath(os.path.dirname(__file__))
-PREFER_CLOUD = True  # Do you prefer URIs pointing to the Amazon bucket when available?
-DOWNLOAD_CLOUD = True
 
 from .version import __version__
 
@@ -30,6 +28,12 @@ class Conf(_config.ConfigNamespace):
     cache_dir
         Default cache directory for data files downloaded, etc. Defaults to ``~/.lksearch/cache`` if not specified.
 
+    PREFER_CLOUD
+        Use Cloud-based data product retrieval where available (primarily Amazon S3 buckets for MAST holdings)
+
+    DOWNLOAD_CLOUD
+       Download cloud based data. If False, download() will return a pointer to the cloud based data instead of
+       downloading it - intended usage for cloud-based science platforms (e.g. TIKE)
     """
 
     # Note: when using list or string_list datatype,
@@ -42,7 +46,7 @@ class Conf(_config.ConfigNamespace):
         [],
         "List of extra columns to be included when displaying a SearchResult object.",
         cfgtype="string_list",
-        module="lksearch.search",
+        module="lksearch",
     )
 
     cache_dir = _config.ConfigItem(
@@ -50,6 +54,28 @@ class Conf(_config.ConfigNamespace):
         "Default cache directory for data files downloaded, etc.",
         cfgtype="string",
         module="lksearch.config",
+    )
+
+    CLOUD_ONLY = _config.ConfigItem(
+        False,
+        "Only Download cloud based data."
+        "If False, will download all data"
+        "If True, will only download data located on a cloud (Amazon S3) bucket",
+        cfgtype="boolean",
+    )
+
+    PREFER_CLOUD = _config.ConfigItem(
+        True,
+        "Prefer Cloud-based data product retrieval where available",
+        cfgtype="boolean",
+    )
+
+    DOWNLOAD_CLOUD = _config.ConfigItem(
+        True,
+        "Download cloud based data."
+        "If False, download() will return a pointer to the cloud based data"
+        "instead of downloading it - intended usage for cloud-based science platforms (e.g. TIKE)",
+        cfgtype="boolean",
     )
 
 

--- a/src/lksearch/config/__init__.py
+++ b/src/lksearch/config/__init__.py
@@ -76,7 +76,7 @@ def get_cache_dir():
     cachedir : str
         The absolute path to the cache directory.
 
-    See :ref:`configuration <api.config>` for more information.
+    See `~lksearch.Conf` for more information.
     """
     from .. import conf
 
@@ -108,6 +108,14 @@ def _ensure_cache_dir_exists(cache_dir):
 
 
 def clearcache(test=True):
+    """Deletes all downloaded files in the lksearch download directory
+
+    Parameters
+    ----------
+    test : bool, optional
+       perform this in test mode, printing what folders will be deleted, by default True.
+       Set test=False to delete cache
+    """
     # Check to see if default download dir/mastDownload exists
     mastdir = f"{get_cache_dir()}/mastDownload"
     if os.path.isdir(mastdir):

--- a/src/lksearch/config/__init__.py
+++ b/src/lksearch/config/__init__.py
@@ -3,19 +3,16 @@ import warnings
 import glob
 import shutil
 
-import astropy.config as astropyconfig
-
+import astropy.config as _config
 
 ROOTNAME = "lksearch"
-PREFER_CLOUD = True  # Do you prefer URIs pointing to the Amazon bucket when available?
-DOWNLOAD_CLOUD = True
 
 
-class ConfigNamespace(astropyconfig.ConfigNamespace):
+class ConfigNamespace(_config.ConfigNamespace):
     rootname = ROOTNAME
 
 
-class ConfigItem(astropyconfig.ConfigItem):
+class ConfigItem(_config.ConfigItem):
     rootname = ROOTNAME
 
 
@@ -35,7 +32,30 @@ def get_config_dir():
         The absolute path to the configuration directory.
 
     """
-    return astropyconfig.get_config_dir(ROOTNAME)
+    return _config.get_config_dir(ROOTNAME)
+
+
+def get_config_file():
+    return f"{get_config_dir()}/{ROOTNAME}.cfg"
+
+
+def create_config_file(overwrite: bool = False):
+    """Creates a default configuration file in the config directory"""
+
+    from .. import conf
+
+    # check if config file exists
+    path_to_config_file = get_config_file()
+    cfg_exists = os.path.isfile(path_to_config_file)
+
+    if not cfg_exists or (cfg_exists and overwrite):
+        with open(path_to_config_file, "w", encoding="utf-8") as f:
+            for item in conf.items():
+                f.write(f"## {item[1].description} \n")
+                f.write(f"# {item[0]} = {item[1].defaultvalue} \n")
+                f.write("\n")
+    else:
+        log.error("Config file exists and overwrite set to {overwrite}")
 
 
 def get_cache_dir():
@@ -62,7 +82,7 @@ def get_cache_dir():
 
     cache_dir = conf.cache_dir
     if cache_dir is None or cache_dir == "":
-        cache_dir = astropyconfig.get_cache_dir(ROOTNAME)
+        cache_dir = _config.get_cache_dir(ROOTNAME)
     cache_dir = _ensure_cache_dir_exists(cache_dir)
     cache_dir = os.path.abspath(cache_dir)
 


### PR DESCRIPTION
Two Major Features:
1. Reworked the configuration parameter to be  fully astropy configuration namespace compatible.  Added a convenience function to write a default config file.  Updated the sample notebook with configuration file and cache directory examples.  
2. Added functionality related to the DOWNLOAD_CLOUD configuration parameter.  If False, this will return the location of MAST cloud bucket location for the file instead of downloading it directly.  The intended use case for this is cloud-based compute platforms like TIKE where we would rather remote-read a file that is on the cloud than download it directly.  Added tests for this as well.  

This also includes a number of smaller fixes and updates, including:

- documentation changes - added citation and community contribution guidelines (just linking to the relevant Lightkurve documentation pages).
- fixed an issue in the __getitem__ where trying to mask via a pandas series returned a datafram and not a lksearch object
- the MASTSearch.cloud_uris parameter was breaking for TESSSearch, since pandas.concat adds nans to missing columns when the TESScut results are added in.  I've fixed the immediate case and added a regression test, but am concerned that these nans may show up again elsewhere.  Is this brittle?  Should we redo something?  This is a separate issue.  
- A bunch of the configuration parameters were being treated a little inconsistently, I streamlined these
